### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -4,7 +4,7 @@
    set -g theme_display_git_untracked no
 
 function _git_branch_name
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2>/dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _is_git_dirty
@@ -13,7 +13,7 @@ function _is_git_dirty
   if [ "$theme_display_git_untracked" = 'no' -o "$show_untracked" = 'false' ]
     set untracked '--untracked-files=no'
   end
-  echo (command git status -s --ignore-submodules=dirty $untracked ^/dev/null)
+  echo (command git status -s --ignore-submodules=dirty $untracked 2>/dev/null)
 end
 
  function fish_prompt
@@ -27,14 +27,14 @@ end
    set -l normal (set_color   normal)
    set -l normal (set_color -o normal)
    set -l white (set_color -o white)
-   
+
 
    set -l cwd (basename (prompt_pwd))
- 
+
    if [ (_git_branch_name) ]
    set -l git_branch $red(_git_branch_name)
    set git_info "$blue git:($git_branch$blue)"
- 
+
      if [ (_is_git_dirty) ]
      set -l dirty "$yellow✗"
        set git_info "$git_info$dirty"


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
